### PR TITLE
v0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rdf-canon"
 authors = ["yamdan"]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ _:c14n2 <http://example.org/vocab#prev> _:c14n0 .
 
 ## Changelog
 
+### v0.4.0
+
+- Add `serialize` function to serialize a normalized dataset into a canonical N-Quads document
+- Add an example into README
+
 ### v0.3.0
 
 - Revise input/output of canonicalization using OxRDF `Dataset` instead of `Vec<Quad>`

--- a/src/canon.rs
+++ b/src/canon.rs
@@ -524,6 +524,19 @@ pub fn canonicalize(input_dataset: &Dataset) -> Result<Dataset, Canonicalization
     normalized_dataset
 }
 
+/// **5. Serialization**
+///   The serialized canonical form of a normalized dataset is an N-Quads document [N-QUADS]
+///   created by representing each quad from the normalized dataset in canonical n-quads form,
+///   sorting them into code point order, and concatenating them.
+pub fn serialize(dataset: Dataset) -> String {
+    let mut ordered_dataset: Vec<QuadRef> = dataset.iter().collect();
+    ordered_dataset.sort_by_cached_key(|q| q.to_string());
+    ordered_dataset
+        .iter()
+        .map(|q| q.to_string() + " .\n")
+        .collect()
+}
+
 /// **4.7 Hash First Degree Quads**
 ///   This algorithm calculates a hash for a given blank node across the
 ///   quads in a dataset in which that blank node is a component. If the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,13 @@
 pub mod canon;
 pub mod error;
-pub use crate::canon::canonicalize;
+pub use crate::canon::{canonicalize, serialize};
 pub use crate::error::CanonicalizationError;
 
 #[cfg(test)]
 mod tests {
-    use crate::canon::canonicalize;
+    use crate::canon::{canonicalize, serialize};
     use oxigraph::io::{DatasetFormat, DatasetParser};
-    use oxrdf::{Dataset, QuadRef};
+    use oxrdf::Dataset;
     use std::{
         fs::File,
         io::{BufReader, Read},
@@ -66,14 +66,8 @@ mod tests {
             let input_dataset =
                 Dataset::from_iter(parser.read_quads(file).unwrap().map(|x| x.unwrap()));
 
-            let canonicalized_dataset = canonicalize(&input_dataset).unwrap();
-            let mut ordered_canonicalized_dataset: Vec<QuadRef> =
-                canonicalized_dataset.iter().collect();
-            ordered_canonicalized_dataset.sort_by_cached_key(|q| q.to_string());
-            let ordered_canonicalized_document: String = ordered_canonicalized_dataset
-                .iter()
-                .map(|q| q.to_string() + " .\n")
-                .collect();
+            let normalized_dataset = canonicalize(&input_dataset).unwrap();
+            let canonicalized_document = serialize(normalized_dataset);
 
             let output_path = format!("{BASE_PATH}/test{:03}-urdna2015.nq", i);
             let expected_output = match read_nquads(&output_path) {
@@ -82,7 +76,7 @@ mod tests {
             };
 
             assert_eq!(
-                ordered_canonicalized_document, expected_output,
+                canonicalized_document, expected_output,
                 "Failed: test{:03}",
                 i
             );


### PR DESCRIPTION
- Add `serialize` function to serialize a normalized dataset into a canonical N-Quads document
- Add an example into README