### PR TITLE
Turn logger into a feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /Cargo.lock
 .devcontainer/
+.vscode/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ tracing = "0.1"
 
 [dev-dependencies]
 tracing-subscriber = "0.3"
+
+[features]
+log = []

--- a/src/canon.rs
+++ b/src/canon.rs
@@ -8,6 +8,8 @@ use oxrdf::{
 };
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
+
+#[cfg(feature = "log")]
 use tracing::{debug, debug_span};
 
 /// **4.3 Canonicalization State**
@@ -76,6 +78,7 @@ impl CanonicalizationState {
         self.blank_node_to_quads_map.get(identifier)
     }
 
+    #[cfg(feature = "log")]
     fn serialize_blank_node_to_quads_map(&self) -> BTreeMap<String, Vec<String>> {
         self.blank_node_to_quads_map
             .iter()
@@ -163,6 +166,7 @@ impl IdentifierIssuer {
         issued_identifier
     }
 
+    #[cfg(feature = "log")]
     fn serialize_issued_identifiers_map(&self) -> String {
         format!(
             "{{{}}}",
@@ -251,67 +255,64 @@ fn canonicalize_blank_node(
 ///   The canonicalization algorithm converts an input dataset into a normalized dataset.
 ///   This algorithm will assign deterministic identifiers to any blank nodes in the input dataset.
 pub fn canonicalize(input_dataset: &Dataset) -> Result<Dataset, CanonicalizationError> {
-    // * log * //
+    #[cfg(feature = "log")]
     let _span_ca = debug_span!(
         "ca",
         message = "log point: Entering the canonicalization function (4.5.3)."
     )
     .entered();
-    // * log * //
 
     // 1) Create the canonicalization state.
     let mut state = CanonicalizationState::new();
 
     // 2) For every quad Q in input dataset:
-    // * log * //
+    #[cfg(feature = "log")]
     let span_ca_2 = debug_span!(
         "ca.2",
         message = "log point: Extract quads for each bnode (4.5.3 (2))."
     )
     .entered();
-    // * log * //
 
     // 2.1) For each blank node that is a component of Q, add a reference to Q from the map
     // entry for the blank node identifier identifier in the blank node to quads map,
     // creating a new entry if necessary.
     state.update_blank_node_to_quads_map(input_dataset);
 
-    // * log * //
-    debug!("Bnode to quads:");
-    for (bnode_id, quads) in state.serialize_blank_node_to_quads_map().iter() {
-        debug!(indent = 1, "{}:", bnode_id);
-        for quad in quads.iter() {
-            debug!(indent = 2, "- {}", quad.trim_end());
+    #[cfg(feature = "log")]
+    {
+        debug!("Bnode to quads:");
+        for (bnode_id, quads) in state.serialize_blank_node_to_quads_map().iter() {
+            debug!(indent = 1, "{}:", bnode_id);
+            for quad in quads.iter() {
+                debug!(indent = 2, "- {}", quad.trim_end());
+            }
         }
     }
+    #[cfg(feature = "log")]
     span_ca_2.exit();
-    // * log * //
 
     // 3) For each key n in the blank node to quads map:
-    // * log * //
+    #[cfg(feature = "log")]
     let span_ca_3 = debug_span!(
         "ca.3",
         message = "log point: Calculated first degree hashes (4.5.3 (3))."
     )
     .entered();
+    #[cfg(feature = "log")]
     debug!("with:");
-    // * log * //
 
     for (n, _quads) in state.blank_node_to_quads_map.iter() {
-        // * log * //
+        #[cfg(feature = "log")]
         debug!(indent = 1, "- identifier: {}", n);
-        // * log * //
 
         // 3.1) Create a hash, h_f(n), for n according to the Hash First Degree Quads algorithm.
-        // * log * //
+        #[cfg(feature = "log")]
         let span_ca_3_1 = debug_span!("", indent = 1).entered();
-        // * log * //
 
         let hash = hash_first_degree_quads(&state, n).unwrap();
 
-        // * log * //
+        #[cfg(feature = "log")]
         span_ca_3_1.exit();
-        // * log * //
 
         // 3.2) Add h_f(n) and n to hash to blank nodes map, including repetitions, creating a new entry if necessary.
         state
@@ -320,20 +321,20 @@ pub fn canonicalize(input_dataset: &Dataset) -> Result<Dataset, Canonicalization
             .or_insert_with(Vec::<String>::new)
             .push(n.clone());
     }
-    // * log * //
+
+    #[cfg(feature = "log")]
     span_ca_3.exit();
-    // * log * //
 
     // 4) For each hash to identifier list map entry in hash to blank nodes map, code point ordered by hash:
     // TODO: check if `sort()` here is actually sorting in **Unicode code point order**
-    // * log * //
+    #[cfg(feature = "log")]    
     let span_ca_4 = debug_span!(
         "ca.4",
         message = "log point: Create canonical replacements for hashes mapping to a single node (4.5.3 (4))."
     )
     .entered();
+    #[cfg(feature = "log")]
     debug!("with:");
-    // * log * //
 
     let mut new_hash_to_blank_node_map = state.hash_to_blank_node_map.clone();
     for (hash, identifier_list) in state.hash_to_blank_node_map.iter() {
@@ -343,49 +344,49 @@ pub fn canonicalize(input_dataset: &Dataset) -> Result<Dataset, Canonicalization
         }
         let identifier = &identifier_list[0];
 
-        // * log * //
-        debug!(indent = 1, "- identifier: {}", identifier);
-        debug!("hash: {}", hash);
-        // * log * //
+        #[cfg(feature = "log")]
+        {
+            debug!(indent = 1, "- identifier: {}", identifier);
+            debug!("hash: {}", hash);
+        }
 
         // 4.2) Use the Issue Identifier algorithm, passing canonical issuer and the single blank node identifier,
         // identifier in identifier list to issue a canonical replacement identifier for identifier.
         let _canonical_identifier = state.canonical_issuer.issue(identifier);
 
-        // * log * //
+        #[cfg(feature = "log")]
         debug!("canonical label: {}", _canonical_identifier);
-        // * log * //
 
         // 4.3) Remove the map entry for hash from the hash to blank nodes map.
         new_hash_to_blank_node_map.remove(hash);
     }
     state.hash_to_blank_node_map = new_hash_to_blank_node_map;
 
-    // * log * //
+    #[cfg(feature = "log")]
     span_ca_4.exit();
-    // * log * //
 
     // 5) For each hash to identifier list map entry in hash to blank nodes map, code point ordered by hash:
-    // * log * //
+    #[cfg(feature = "log")]
     let span_ca_5 = debug_span!(
         "ca.5",
         message = "log point: Calculate hashes for identifiers with shared hashes (4.5.3 (5))."
     )
     .entered();
+    #[cfg(feature = "log")]
     debug!("with:");
-    // * log * //
 
     for (_hash, identifier_list) in state.hash_to_blank_node_map.iter() {
-        // * log * //
-        debug!(indent = 1, "- hash: {}", _hash);
-        debug!(indent = 2, "identifier list: {:?}", identifier_list);
-        // * log * //
+        #[cfg(feature = "log")]
+        {
+            debug!(indent = 1, "- hash: {}", _hash);
+            debug!(indent = 2, "identifier list: {:?}", identifier_list);
+        }
 
         // 5.1) Create hash path list where each item will be a result of running the Hash N-Degree Quads algorithm.
         let mut hash_path_list = Vec::<HashNDegreeQuadsResult>::new();
 
         // 5.2) For each blank node identifier n in identifier list:
-        // * log * //
+        #[cfg(feature = "log")]
         let span_ca_5_2 = debug_span!(
             "ca.5.2",
             message =
@@ -393,13 +394,12 @@ pub fn canonicalize(input_dataset: &Dataset) -> Result<Dataset, Canonicalization
             indent = 2
         )
         .entered();
+        #[cfg(feature = "log")]
         debug!("with:");
-        // * log * //
 
         for n in identifier_list {
-            // * log * //
+            #[cfg(feature = "log")]
             debug!(indent = 1, "- identifier: {}", n);
-            // * log * //
 
             // 5.2.1) If a canonical identifier has already been issued for n, continue to the next blank node
             // identifier.
@@ -416,97 +416,89 @@ pub fn canonicalize(input_dataset: &Dataset) -> Result<Dataset, Canonicalization
 
             // 5.2.4) Run the Hash N-Degree Quads algorithm, passing the canonicalization state, n for identifier,
             // and temporary issuer, appending the result to the hash path list.
-            // * log * //
+            #[cfg(feature = "log")]
             let span_ca_5_2_4 = debug_span!("", indent = 1).entered();
-            // * log * //
 
             let result = hash_n_degree_quads(&state, n.clone(), &temporary_issuer).unwrap();
 
-            // * log * //
+            #[cfg(feature = "log")]
             span_ca_5_2_4.exit();
-            // * log * //
 
             hash_path_list.push(result);
         }
 
-        // * log * //
+        #[cfg(feature = "log")]
         span_ca_5_2.exit();
-        // * log * //
 
         // 5.3) For each result in the hash path list, code point ordered by the hash in result:
 
-        // * log * //
+        #[cfg(feature = "log")]
         let span_ca_5_3 = debug_span!(
             "ca.5.3",
             message = "log point: Canonical identifiers for temporary identifiers (4.5.3 (5.3)).",
             indent = 2
         )
         .entered();
+        #[cfg(feature = "log")]
         if !hash_path_list.is_empty() {
             debug!("with:");
         }
-        // * log * //
 
         hash_path_list.sort();
         for result in hash_path_list.iter() {
-            // * log * //
-            debug!(indent = 1, "- result: {}", result.hash);
-            debug!(
-                indent = 2,
-                "issuer: {}",
-                result.issuer.serialize_issued_identifiers_map()
-            );
-            // * log * //
+            #[cfg(feature = "log")]
+            {
+                debug!(indent = 1, "- result: {}", result.hash);
+                debug!(
+                    indent = 2,
+                    "issuer: {}",
+                    result.issuer.serialize_issued_identifiers_map()
+                );
+            }
 
             // 5.3.1) For each blank node identifier, existing identifier, that was issued a temporary identifier
             // by identifier issuer in result, issue a canonical identifier, in the same order, using the Issue
             // Identifier algorithm, passing canonical issuer and existing identifier.
 
-            // * log * //
+            #[cfg(feature = "log")]
             let span_ca_5_3_1 = debug_span!("ca.5.3.1", indent = 2).entered();
-            // * log * //
 
             for (existing_identifier, _temporary_identifier) in
                 result.issuer.issued_identifiers_map.iter()
             {
-                // * log * //
+                #[cfg(feature = "log")]
                 debug!("- existing identifier: {}", existing_identifier);
-                // * log * //
 
                 let _canonical_identifier = state.canonical_issuer.issue(existing_identifier);
 
-                // * log * //
+                #[cfg(feature = "log")]
                 debug!(indent = 1, "cid: {}", _canonical_identifier);
-                // * log * //
             }
 
-            // * log * //
+            #[cfg(feature = "log")]
             span_ca_5_3_1.exit();
-            // * log * //
         }
 
-        // * log * //
+        #[cfg(feature = "log")]
         span_ca_5_3.exit();
-        // * log * //
     }
 
-    // * log * //
+    #[cfg(feature = "log")]
     span_ca_5.exit();
-    // * log * //
 
     // 6) For each quad, q, in input dataset:
 
-    // * log * //
+    #[cfg(feature = "log")]
     let span_ca_6 = debug_span!(
         "ca.6",
         message = "log point: Replace original with canonical labels (4.5.3 (6))."
     )
     .entered();
+    #[cfg(feature = "log")]
     debug!(
         "canonical issuer: {}",
         state.canonical_issuer.serialize_issued_identifiers_map()
     );
-    // * log * //
 
     // 6.1) Create a copy, quad copy, of q and replace any existing blank node identifier n using the
     // canonical identifiers previously issued by canonical issuer.
@@ -516,9 +508,8 @@ pub fn canonicalize(input_dataset: &Dataset) -> Result<Dataset, Canonicalization
         .map(|q| canonicalize_quad(q, &state.canonical_issuer))
         .collect();
 
-    // * log * //
+    #[cfg(feature = "log")]
     span_ca_6.exit();
-    // * log * //
 
     // 7) Return the normalized dataset.
     normalized_dataset
@@ -551,6 +542,7 @@ fn hash_first_degree_quads(
     canonicalization_state: &CanonicalizationState,
     reference_blank_node_identifier: &String,
 ) -> Result<String, CanonicalizationError> {
+    #[cfg(feature = "log")]
     let _span_h1dq = debug_span!(
         "h1dq",
         message = "log point: Hash First Degree Quads function (4.7.3)."
@@ -615,12 +607,13 @@ fn hash_first_degree_quads(
         }
     }
 
-    // * log * //
-    debug!("nquads:");
-    for nquad in nquads.iter() {
-        debug!(indent = 1, "- {}", nquad.trim_end());
+    #[cfg(feature = "log")]
+    {
+        debug!("nquads:");
+        for nquad in nquads.iter() {
+            debug!(indent = 1, "- {}", nquad.trim_end());
+        }
     }
-    // * log * //
 
     // 4) Sort nquads in Unicode code point order.
     // TODO: check if `sort()` here is actually sorting in **Unicode code point order**
@@ -629,7 +622,10 @@ fn hash_first_degree_quads(
     // 5) Return the hash that results from passing the sorted and concatenated
     // nquads through the hash algorithm.
     let hashed_nquads = hash(nquads.join(""));
+
+    #[cfg(feature = "log")]
     debug!("hash: {}", hashed_nquads.clone().unwrap_or_default());
+
     hashed_nquads
 }
 
@@ -660,10 +656,11 @@ fn hash_related_blank_node(
     issuer: &IdentifierIssuer,
     position: HashRelatedBlankNodePosition,
 ) -> Result<String, CanonicalizationError> {
-    // * log * //
-    debug!("- position: {}", position.serialize());
-    debug!(indent = 1, "related: {}", related);
-    // * log * //
+    #[cfg(feature = "log")]
+    {
+        debug!("- position: {}", position.serialize());
+        debug!(indent = 1, "related: {}", related);
+    }
 
     // 1) Initialize a string input to the value of position.
     let input = match position {
@@ -676,9 +673,8 @@ fn hash_related_blank_node(
     // append the string _:, followed by that identifier (using the canonical identifier if
     // present, otherwise the one issued by issuer) to input.
 
-    // * log * //
+    #[cfg(feature = "log")]
     let span_hrbn_3 = debug_span!("").entered();
-    // * log * //
 
     let identifier = match state.canonical_issuer.get(related) {
         Some(id) => format!("_:{}", id),
@@ -690,22 +686,19 @@ fn hash_related_blank_node(
         },
     };
 
-    // * log * //
+    #[cfg(feature = "log")]
     span_hrbn_3.exit();
-    // * log * //
 
     let input = format!("{}{}", input, identifier);
 
-    // * log * //
+    #[cfg(feature = "log")]
     debug!(indent = 1, "input: \"{}\"", input);
-    // * log * //
 
     // 5) Return the hash that results from passing input through the hash algorithm.
     let output = hash(input);
 
-    // * log * //
+    #[cfg(feature = "log")]
     debug!(indent = 1, "hash: {}", output.clone().unwrap_or_default());
-    // * log * //
 
     output
 }
@@ -745,19 +738,20 @@ fn hash_n_degree_quads(
     identifier: String,
     path_identifier_issuer: &IdentifierIssuer,
 ) -> Result<HashNDegreeQuadsResult, CanonicalizationError> {
-    // * log * //
+    #[cfg(feature = "log")]
     let _span_hndq = debug_span!(
         "hndq",
         message = "log point: Hash N-Degree Quads function (4.9.3)."
     )
     .entered();
-    // * log * //
-
-    debug!("identifier: {}", identifier);
-    debug!(
-        "issuer: {}",
-        path_identifier_issuer.serialize_issued_identifiers_map()
-    );
+    #[cfg(feature = "log")]
+    {
+        debug!("identifier: {}", identifier);
+        debug!(
+            "issuer: {}",
+            path_identifier_issuer.serialize_issued_identifiers_map()
+        );
+    }
 
     let mut issuer = path_identifier_issuer.clone();
 
@@ -766,48 +760,50 @@ fn hash_n_degree_quads(
 
     // 2) Get a reference, quads, to the list of quads from the map entry for identifier
     // in the blank node to quads map.
-    // * log * //
+    #[cfg(feature = "log")]
     let span_hndq_2 = debug_span!(
         "hndq.2",
         message = "log point: Quads for identifier (4.9.3 (2))."
     )
     .entered();
-    // * log * //
 
     let quads = match state.get_quads_for_blank_node(&identifier) {
         Some(q) => q,
         None => return Err(CanonicalizationError::QuadsNotExist),
     };
-    debug!("quads:");
-    for quad in quads {
-        debug!(indent = 1, "- {}", quad.to_string().trim_end());
-    }
 
-    // * log * //
+    #[cfg(feature = "log")]
+    {
+        debug!("quads:");
+        for quad in quads {
+            debug!(indent = 1, "- {}", quad.to_string().trim_end());
+        }
+    }
+    #[cfg(feature = "log")]
     span_hndq_2.exit();
-    // * log * //
 
     // 3) For each quad in quads:
-    // * log * //
+    #[cfg(feature = "log")]
     let span_hndq_3 = debug_span!(
         "hndq.3",
         message = "log point: Hash N-Degree Quads function (4.9.3 (3))."
     )
     .entered();
+    #[cfg(feature = "log")]
     debug!("with:");
-    // * log * //
 
     for quad in quads {
-        // * log * //
+        #[cfg(feature = "log")]
         debug!(indent = 1, "- quad: {}", quad.to_string().trim_end());
+        #[cfg(feature = "log")]
         let span_hndq_3_1 = debug_span!(
             "hndq.3.1",
             message = "log point: Hash related bnode component (4.9.3 (3.1)).",
             indent = 2
         )
         .entered();
+        #[cfg(feature = "log")]
         let mut span_hndq_3_1_flag = false;
-        // * log * //
 
         // 3.1) For each component in quad, where component is the subject, object, or graph name,
         // and it is a blank node that is not identified by identifier:
@@ -819,12 +815,11 @@ fn hash_n_degree_quads(
                 // as either s, o, or g based on whether component is a subject, object, graph name,
                 // respectively.
 
-                // * log * //
+                #[cfg(feature = "log")]
                 if !span_hndq_3_1_flag {
                     debug!("with:");
                     span_hndq_3_1_flag = true;
                 }
-                // * log * //
 
                 let hash = hash_related_blank_node(
                     state,
@@ -851,12 +846,11 @@ fn hash_n_degree_quads(
                 // as either s, o, or g based on whether component is a subject, object, graph name,
                 // respectively.
 
-                // * log * //
+                #[cfg(feature = "log")]
                 if !span_hndq_3_1_flag {
                     debug!("with:");
                     span_hndq_3_1_flag = true;
                 }
-                // * log * //
 
                 let hash = hash_related_blank_node(
                     state,
@@ -883,11 +877,10 @@ fn hash_n_degree_quads(
                 // as either s, o, or g based on whether component is a subject, object, graph name,
                 // respectively.
 
-                // * log * //
+                #[cfg(feature = "log")]
                 if !span_hndq_3_1_flag {
                     debug!("with:");
                 }
-                // * log * //
 
                 let hash = hash_related_blank_node(
                     state,
@@ -905,21 +898,22 @@ fn hash_n_degree_quads(
             };
         };
 
-        // * log * //
+        #[cfg(feature = "log")]
         span_hndq_3_1.exit();
-        // * log * //
     }
 
-    // * log * //
-    debug!("Hash to bnodes:");
-    for (hash, bnodes) in h_n.iter() {
-        debug!(indent = 1, "{}:", hash);
-        for bnode in bnodes.iter() {
-            debug!(indent = 2, "- {}", bnode);
+    #[cfg(feature = "log")]
+    {
+        debug!("Hash to bnodes:");
+        for (hash, bnodes) in h_n.iter() {
+            debug!(indent = 1, "{}:", hash);
+            for bnode in bnodes.iter() {
+                debug!(indent = 2, "- {}", bnode);
+            }
         }
     }
+    #[cfg(feature = "log")]
     span_hndq_3.exit();
-    // * log * //
 
     // 4) Create an empty string, data to hash.
     let mut data_to_hash = Vec::<String>::new();
@@ -927,20 +921,21 @@ fn hash_n_degree_quads(
     // 5) For each related hash to blank node list mapping in Hn, code point ordered by related hash:
     // TODO: check if keys in BTreeMap is actually sorted in **code point order**
 
-    // * log * //
+    #[cfg(feature = "log")]
     let span_hndq_5 = debug_span!(
         "hndq.5",
         message = "log point: Hash N-Degree Quads function (4.9.3 (5)), entering loop."
     )
     .entered();
+    #[cfg(feature = "log")]
     debug!("with:");
-    // * log * //
 
     for (related_hash, blank_node_list) in h_n {
-        // * log * //
-        debug!(indent = 1, "- related hash: {}", related_hash);
-        debug!(indent = 2, "data to hash: \"{}\"", data_to_hash.join(""));
-        // * log * //
+        #[cfg(feature = "log")]
+        {
+            debug!(indent = 1, "- related hash: {}", related_hash);
+            debug!(indent = 2, "data to hash: \"{}\"", data_to_hash.join(""));
+        }
 
         // 5.1) Append the related hash to the data to hash.
         data_to_hash.push(related_hash);
@@ -953,20 +948,20 @@ fn hash_n_degree_quads(
 
         // 5.4) For each permutation p of blank node list:
 
-        // * log * //
+        #[cfg(feature = "log")]
         let span_hndq_5_4 = debug_span!(
             "hndq.5.4",
             message = "log point: Hash N-Degree Quads function (4.9.3 (5.4)), entering loop.",
             indent = 2
         )
         .entered();
-        // * log * //
 
         'perm_loop: for p in blank_node_list.iter().permutations(blank_node_list.len()) {
-            // * log * //
-            debug!("with:");
-            debug!(indent = 1, "- perm: {:?}", p);
-            // * log * //
+            #[cfg(feature = "log")]
+            {
+                debug!("with:");
+                debug!(indent = 1, "- perm: {:?}", p);
+            }
 
             // 5.4.1) Create a copy of issuer, issuer copy.
             let mut issuer_copy = issuer.clone();
@@ -979,21 +974,19 @@ fn hash_n_degree_quads(
             let mut recursion_list = Vec::<&String>::new();
 
             // 5.4.4) For each related in p:
-
-            // * log * //
+            #[cfg(feature = "log")]
             let span_hndq_5_4_4 = debug_span!(
                 "hndq.5.4.4",
                 message = "log point: Hash N-Degree Quads function (4.9.3 (5.4.4)), entering loop.",
                 indent = 2
             )
             .entered();
+            #[cfg(feature = "log")]
             debug!("with:");
-            // * log * //
 
             for related in p {
-                // * log * //
+                #[cfg(feature = "log")]
                 debug!(indent = 1, "- related: {}", related);
-                // * log * //
 
                 if let Some(canonical_identifier) = state.canonical_issuer.get(related) {
                     // 5.4.4.1) If a canonical identifier has been issued for related by
@@ -1019,9 +1012,8 @@ fn hash_n_degree_quads(
                 // permutation p.
                 let path = path_vec.join("");
 
-                // * log * //
+                #[cfg(feature = "log")]
                 debug!(indent = 2, "path: \"{}\"", path);
-                // * log * //
 
                 if !chosen_path.is_empty() && path.len() >= chosen_path.len() && path >= chosen_path
                 {
@@ -1029,44 +1021,42 @@ fn hash_n_degree_quads(
                 }
             }
 
-            // * log * //
+            #[cfg(feature = "log")]
             span_hndq_5_4_4.exit();
-            // * log * //
 
             // 5.4.5) For each related in recursion list:
 
-            // * log * //
-            let span_hndq_5_4_5 = debug_span!(
+            #[cfg(feature = "log")]
+                let span_hndq_5_4_5 = debug_span!(
                 "hndq.5.4.5",
                 message = "log point: Hash N-Degree Quads function (4.9.3 (5.4.5)), before possible recursion.",
                 indent = 2
             )
             .entered();
-            debug!("recursion list: {:?}", recursion_list);
-            debug!("path: {:?}", chosen_path);
-            if !recursion_list.is_empty() {
-                debug!("with:");
+            #[cfg(feature = "log")]
+            {
+                debug!("recursion list: {:?}", recursion_list);
+                debug!("path: {:?}", chosen_path);
+                if !recursion_list.is_empty() {
+                    debug!("with:");
+                }
             }
-            // * log * //
 
             for related in recursion_list {
-                // * log * //
+                #[cfg(feature = "log")]
                 debug!(indent = 1, "- related: {}", related);
-                // * log * //
 
                 // 5.4.5.1) Set result to the result of recursively executing the Hash
                 // N-Degree Quads algorithm, passing the canonicalization state, related
                 // for identifier, and issuer copy for path identifier issuer.
 
-                // * log * //
+                #[cfg(feature = "log")]
                 let span_hndq_5_4_5_1 = debug_span!("", indent = 1).entered();
-                // * log * //
 
                 let result = hash_n_degree_quads(state, related.clone(), &issuer_copy)?;
 
-                // * log * //
+                #[cfg(feature = "log")]
                 span_hndq_5_4_5_1.exit();
-                // * log * //
 
                 // 5.4.5.2) Use the Issue Identifier algorithm, passing issuer copy and
                 // related; append the string _:, followed by the result, to path.
@@ -1079,25 +1069,26 @@ fn hash_n_degree_quads(
 
                 // 5.4.5.4) Set issuer copy to the identifier issuer in result.
 
-                // * log * //
+                #[cfg(feature="log")]
                 let span_hndq_5_4_5_4 = debug_span!(
                     "hndq.5.4.5.4",
                     message = "log point: Hash N-Degree Quads function (4.9.3 (5.4.5.4)), combine result of recursion.",
                     indent = 2
                 ).entered();
-                // * log * //
 
                 issuer_copy = result.issuer;
                 let path = path_vec.join("");
 
-                // * log * //
-                debug!("path: \"{}\"", path);
-                debug!(
-                    "issuer copy: {}",
-                    issuer_copy.serialize_issued_identifiers_map()
-                );
+                #[cfg(feature = "log")]
+                {
+                    debug!("path: \"{}\"", path);
+                    debug!(
+                        "issuer copy: {}",
+                        issuer_copy.serialize_issued_identifiers_map()
+                    );
+                }
+                #[cfg(feature = "log")]
                 span_hndq_5_4_5_4.exit();
-                // * log * //
 
                 // 5.4.5.5) If chosen path is not empty and the length of path is greater
                 // than or equal to the length of chosen path and path is greater than
@@ -1108,9 +1099,8 @@ fn hash_n_degree_quads(
                 }
             }
 
-            // * log * //
+            #[cfg(feature = "log")]
             span_hndq_5_4_5.exit();
-            // * log * //
 
             // 5.4.6) If chosen path is empty or path is less than chosen path when
             // considering code point order, set chosen path to path and chosen issuer to
@@ -1122,55 +1112,54 @@ fn hash_n_degree_quads(
             }
         }
 
-        // * log * //
+        #[cfg(feature = "log")]
         span_hndq_5_4.exit();
-        // * log * //
 
         // 5.5) Append chosen path to data to hash.
 
-        // * log * //
+        #[cfg(feature = "log")]
         let span_hndq_5_5 = debug_span!(
             "hndq.5.5",
             message = "log point: Hash N-Degree Quads function (4.9.3 (5.5). End of current loop with Hn hashes.",
             indent = 2
         )
         .entered();
+        #[cfg(feature = "log")]
         debug!("chosen path: \"{}\"", chosen_path);
-        // * log * //
 
         data_to_hash.push(chosen_path);
 
-        // * log * //
+        #[cfg(feature = "log")]
         debug!("data to hash: \"{}\"", data_to_hash.join(""));
+        #[cfg(feature = "log")]
         span_hndq_5_5.exit();
-        // * log * //
 
         // 5.6) Replace issuer, by reference, with chosen issuer.
         issuer = chosen_issuer;
     }
 
-    // * log * //
+    #[cfg(feature = "log")]
     span_hndq_5.exit();
-    // * log * //
 
     // 6) Return issuer and the hash that results from passing data to hash through the
     // hash algorithm.
 
-    // * log * //
+    #[cfg(feature = "log")]
     let span_hndq_6 = debug_span!(
         "hndq.6",
         message = "log point: Leaving Hash N-Degree Quads function (4.9.3 (6))."
     )
     .entered();
-    // * log * //
 
     let hash = hash(data_to_hash.join(""))?;
 
-    // * log * //
-    debug!("hash: {}", hash);
-    debug!("issuer: {}", issuer.serialize_issued_identifiers_map());
+    #[cfg(feature = "log")]
+    {
+        debug!("hash: {}", hash);
+        debug!("issuer: {}", issuer.serialize_issued_identifiers_map());
+    }
+    #[cfg(feature = "log")]
     span_hndq_6.exit();
-    // * log * //
 
     Ok(HashNDegreeQuadsResult { hash, issuer })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,14 +13,20 @@ mod tests {
         io::{BufReader, Read},
         path::Path,
     };
-    use tracing::metadata::LevelFilter;
-    use tracing_subscriber::{fmt, prelude::*};
 
+    #[cfg(feature = "log")]
+    use tracing::metadata::LevelFilter;
+    #[cfg(feature = "log")]
+    use tracing_subscriber::{fmt, prelude::*};
+    #[cfg(feature = "log")]
     mod logger;
+    #[cfg(feature = "log")]
     use logger::CustomLayer;
 
+    #[cfg(feature = "log")]
     const INDENT_WIDTH: usize = 2;
 
+    #[cfg(feature = "log")]
     fn _init(level: tracing::Level) {
         let log_format = fmt::format()
             .with_level(false)
@@ -32,6 +38,7 @@ mod tests {
             .event_format(log_format)
             .try_init();
     }
+    #[cfg(feature = "log")]
     fn init(level: tracing::Level) {
         let _ = tracing_subscriber::registry()
             .with(CustomLayer::new(INDENT_WIDTH).with_filter(LevelFilter::from_level(level)))
@@ -40,6 +47,7 @@ mod tests {
 
     #[test]
     fn test_canonicalize() {
+        #[cfg(feature = "log")]
         init(tracing::Level::INFO);
         // init(tracing::Level::DEBUG);
 

--- a/src/tests/logger.rs
+++ b/src/tests/logger.rs
@@ -71,9 +71,10 @@ where
 
     fn on_event(&self, event: &tracing::Event<'_>, ctx: tracing_subscriber::layer::Context<'_, S>) {
         // load base indent
-        let span = ctx.lookup_current().unwrap();
-        let extensions = span.extensions();
-        let base_indent: &usize = extensions.get().unwrap_or(&0);
+        let base_indent = match ctx.lookup_current() {
+            Some(span) => *span.extensions().get().unwrap_or(&0),
+            None => 0,
+        };
 
         // get delta indent
         let mut visitor = CustomVisitor {


### PR DESCRIPTION
- Turn logger into a feature: the logger can now be optionally included in our builds, depending on the requirements of each specific build.
- Fix logger to avoid unexpected panic
- update .gitignore
