### PR TITLE
V0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rdf-canon"
 authors = ["yamdan"]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -69,7 +69,17 @@ _:c14n2 <http://example.org/vocab#prev> _:c14n0 .
 }
 ```
 
+## Logging feature (for debug)
+
+Enable `log` feature to get the debug log if you want (See [src/lib.rs](src/lib.rs))
+
 ## Changelog
+
+### v0.5.0
+
+- Turn logger into a feature: the logger can now be optionally included in our builds, depending on the requirements of each specific build
+- Fix logger to avoid unexpected panic
+- update `.gitignore`
 
 ### v0.4.0
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ mod tests {
     #[cfg(feature = "log")]
     use tracing::metadata::LevelFilter;
     #[cfg(feature = "log")]
-    use tracing_subscriber::{fmt, prelude::*};
+    use tracing_subscriber::prelude::*;
     #[cfg(feature = "log")]
     mod logger;
     #[cfg(feature = "log")]
@@ -27,19 +27,7 @@ mod tests {
     const INDENT_WIDTH: usize = 2;
 
     #[cfg(feature = "log")]
-    fn _init(level: tracing::Level) {
-        let log_format = fmt::format()
-            .with_level(false)
-            .with_target(false)
-            .without_time()
-            .compact();
-        let _ = fmt()
-            .with_max_level(level)
-            .event_format(log_format)
-            .try_init();
-    }
-    #[cfg(feature = "log")]
-    fn init(level: tracing::Level) {
+    fn init_logger(level: tracing::Level) {
         let _ = tracing_subscriber::registry()
             .with(CustomLayer::new(INDENT_WIDTH).with_filter(LevelFilter::from_level(level)))
             .try_init();
@@ -48,8 +36,8 @@ mod tests {
     #[test]
     fn test_canonicalize() {
         #[cfg(feature = "log")]
-        init(tracing::Level::INFO);
-        // init(tracing::Level::DEBUG);
+        init_logger(tracing::Level::INFO);
+        // init_logger(tracing::Level::DEBUG);
 
         const BASE_PATH: &str = "tests/urdna2015";
 


### PR DESCRIPTION
- refactor logger

### from #6 
- turn logger into a feature: the logger can now be optionally included in our builds, depending on the requirements of each specific build.
- fix logger to avoid unexpected panic
- update .gitignore
