### PR TITLE
v0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rdf-canon"
 authors = ["yamdan"]
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ _:c14n2 <http://example.org/vocab#next> _:c14n1 .
 _:c14n2 <http://example.org/vocab#prev> _:c14n0 .
 "#;
 
-let quads = NQuadsParser::new()
+let input_quads = NQuadsParser::new()
     .parse_from_read(Cursor::new(input))
     .into_iter()
     .map(|x| x.unwrap());
-let input_dataset = Dataset::from_iter(quads);
+let input_dataset = Dataset::from_iter(input_quads);
 let canonicalized = canonicalize(&input_dataset).unwrap();
 
 assert_eq!(canonicalized, expected);
@@ -101,16 +101,15 @@ let expected = HashMap::from([
     ("e2".to_string(), "c14n1".to_string()),
 ]);
 
-let quads = NQuadsParser::new()
+let input_quads = NQuadsParser::new()
     .parse_from_read(Cursor::new(input))
     .into_iter()
     .map(|x| x.unwrap());
-let input_dataset = Dataset::from_iter(quads);
+let input_dataset = Dataset::from_iter(input_quads);
 let issued_identifiers_map = issue(&input_dataset).unwrap();
 
 assert_eq!(issued_identifiers_map, expected);
 ```
-
 
 ### Protecting against poison dataset
 
@@ -141,7 +140,7 @@ oxttl = { git = "https://github.com/oxigraph/oxigraph.git", branch = "next" }
 ```rust
 use oxrdf::Dataset;
 use oxttl::NQuadsParser;
-use rdf_canon::{canonicalize, logger::YamlLayer, serialize};
+use rdf_canon::{canonicalize, logger::YamlLayer};
 use std::io::Cursor;
 
 // setup for debug logger
@@ -158,25 +157,24 @@ fn main() {
     // initialize debug logger
     init_logger(tracing::Level::DEBUG);
 
-    let input_doc = r#"_:e0 <http://example.com/#p1> _:e1 .
+    let input = r#"_:e0 <http://example.com/#p1> _:e1 .
 _:e1 <http://example.com/#p2> "Foo" .
 "#;
-    let expected_doc = r#"_:c14n0 <http://example.com/#p1> _:c14n1 .
+    let expected = r#"_:c14n0 <http://example.com/#p1> _:c14n1 .
 _:c14n1 <http://example.com/#p2> "Foo" .
 "#;
 
     // get dataset from N-Quads document
-    let quads = NQuadsParser::new()
-        .parse_from_read(Cursor::new(input_doc))
+    let input_quads = NQuadsParser::new()
+        .parse_from_read(Cursor::new(input))
         .into_iter()
         .map(|x| x.unwrap());
-    let input_dataset = Dataset::from_iter(quads);
+    let input_dataset = Dataset::from_iter(input_quads);
 
     // canonicalize the dataset
-    let canonicalized_dataset = canonicalize(&input_dataset).unwrap();
-    let canonicalized_doc = serialize(canonicalized_dataset);
+    let canonicalized = canonicalize(&input_dataset).unwrap();
 
-    assert_eq!(canonicalized_doc, expected_doc);
+    assert_eq!(canonicalized, expected);
 }
 ```
 
@@ -184,9 +182,9 @@ The above code generates the following debug log:
 
 ```yaml
 ca:
-  log point: Entering the canonicalization function (4.5.3).
+  log point: Entering the canonicalization function (4.4.3).
   ca.2:
-    log point: Extract quads for each bnode (4.5.3 (2)).
+    log point: Extract quads for each bnode (4.4.3 (2)).
     Bnode to quads:
       e0:
         - _:e0 <http://example.com/#p1> _:e1 .
@@ -194,23 +192,23 @@ ca:
         - _:e0 <http://example.com/#p1> _:e1 .
         - _:e1 <http://example.com/#p2> "Foo" .
   ca.3:
-    log point: Calculated first degree hashes (4.5.3 (3)).
+    log point: Calculated first degree hashes (4.4.3 (3)).
     with:
       - identifier: e0
         h1dq:
-          log point: Hash First Degree Quads function (4.7.3).
+          log point: Hash First Degree Quads function (4.6.3).
           nquads:
             - _:a <http://example.com/#p1> _:z .
           hash: 24da9a4406b4e66dffa10ad3d4d6dddc388fbf193bb124e865158ef419893957
       - identifier: e1
         h1dq:
-          log point: Hash First Degree Quads function (4.7.3).
+          log point: Hash First Degree Quads function (4.6.3).
           nquads:
             - _:z <http://example.com/#p1> _:a .
             - _:a <http://example.com/#p2> "Foo" .
           hash: a994e40b576809985bc0f389308cd9d552fd7c89d028c163848a6b2d33a8583a
   ca.4:
-    log point: Create canonical replacements for hashes mapping to a single node (4.5.3 (4)).
+    log point: Create canonical replacements for hashes mapping to a single node (4.4.3 (4)).
     with:
       - identifier: e0
     hash: 24da9a4406b4e66dffa10ad3d4d6dddc388fbf193bb124e865158ef419893957
@@ -219,11 +217,12 @@ ca:
     hash: a994e40b576809985bc0f389308cd9d552fd7c89d028c163848a6b2d33a8583a
     canonical label: c14n1
   ca.5:
-    log point: Calculate hashes for identifiers with shared hashes (4.5.3 (5)).
+    log point: Calculate hashes for identifiers with shared hashes (4.4.3 (5)).
     with:
   ca.6:
-    log point: Replace original with canonical labels (4.5.3 (6)).
+    log point: Replace original with canonical labels (4.4.3 (6)).
     issued identifiers map: {e0: c14n0, e1: c14n1}
+    hndq_call_counter:  { counter: 0, limit: 4000 }
 ```
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -227,6 +227,10 @@ ca:
 
 ## Changelog
 
+### v0.10.0
+
+- add `*_quads` APIs to allow input in `Vec<quad>` instead of `Dataset`
+
 ### v0.9.1
 
 - fix debug log indentations

--- a/src/api.rs
+++ b/src/api.rs
@@ -37,11 +37,11 @@ use std::collections::HashMap;
 /// _:c14n2 <http://example.org/vocab#prev> _:c14n0 .
 /// "#;
 ///
-/// let quads = NQuadsParser::new()
+/// let input_quads = NQuadsParser::new()
 ///     .parse_from_read(Cursor::new(input))
 ///     .into_iter()
 ///     .map(|x| x.unwrap());
-/// let input_dataset = Dataset::from_iter(quads);
+/// let input_dataset = Dataset::from_iter(input_quads);
 /// let canonicalized = canonicalize(&input_dataset).unwrap();
 ///
 /// assert_eq!(canonicalized, expected);
@@ -85,11 +85,11 @@ pub struct CanonicalizationOptions {
 /// _:c14n2 <http://example.org/vocab#prev> _:c14n0 .
 /// "#;
 ///
-/// let quads = NQuadsParser::new()
+/// let input_quads = NQuadsParser::new()
 ///     .parse_from_read(Cursor::new(input))
 ///     .into_iter()
 ///     .map(|x| x.unwrap());
-/// let input_dataset = Dataset::from_iter(quads);
+/// let input_dataset = Dataset::from_iter(input_quads);
 /// let options = CanonicalizationOptions {
 ///     hndq_call_limit: Some(10000),
 /// };
@@ -126,20 +126,20 @@ pub fn canonicalize_with_options(
 /// _:e2 <http://example.org/vocab#next> _:e0 .
 /// _:e2 <http://example.org/vocab#prev> _:e1 .
 /// "#;
-/// let expected = HashMap::from([
+/// let expected_map = HashMap::from([
 ///     ("e0".to_string(), "c14n0".to_string()),
 ///     ("e1".to_string(), "c14n2".to_string()),
 ///     ("e2".to_string(), "c14n1".to_string()),
 /// ]);
 ///
-/// let quads = NQuadsParser::new()
+/// let input_quads = NQuadsParser::new()
 ///     .parse_from_read(Cursor::new(input))
 ///     .into_iter()
 ///     .map(|x| x.unwrap());
-/// let input_dataset = Dataset::from_iter(quads);
+/// let input_dataset = Dataset::from_iter(input_quads);
 /// let issued_identifiers_map = issue(&input_dataset).unwrap();
 ///
-/// assert_eq!(issued_identifiers_map, expected);
+/// assert_eq!(issued_identifiers_map, expected_map);
 /// ```
 pub fn issue(input_dataset: &Dataset) -> Result<HashMap<String, String>, CanonicalizationError> {
     let options = CanonicalizationOptions::default();
@@ -167,24 +167,24 @@ pub fn issue(input_dataset: &Dataset) -> Result<HashMap<String, String>, Canonic
 /// _:e2 <http://example.org/vocab#next> _:e0 .
 /// _:e2 <http://example.org/vocab#prev> _:e1 .
 /// "#;
-/// let expected = HashMap::from([
+/// let expected_map = HashMap::from([
 ///     ("e0".to_string(), "c14n0".to_string()),
 ///     ("e1".to_string(), "c14n2".to_string()),
 ///     ("e2".to_string(), "c14n1".to_string()),
 /// ]);
 ///
-/// let quads = NQuadsParser::new()
+/// let input_quads = NQuadsParser::new()
 ///     .parse_from_read(Cursor::new(input))
 ///     .into_iter()
 ///     .map(|x| x.unwrap());
-/// let input_dataset = Dataset::from_iter(quads);
+/// let input_dataset = Dataset::from_iter(input_quads);
 /// let options = CanonicalizationOptions {
 ///     hndq_call_limit: Some(10000),
 /// };
 ///
 /// let issued_identifiers_map = issue_with_options(&input_dataset, &options).unwrap();
 ///
-/// assert_eq!(issued_identifiers_map, expected);
+/// assert_eq!(issued_identifiers_map, expected_map);
 /// ```
 pub fn issue_with_options(
     input_dataset: &Dataset,
@@ -205,7 +205,7 @@ pub fn issue_with_options(
 /// use std::collections::HashMap;
 /// use std::io::Cursor;
 ///
-/// let input_doc = r#"
+/// let input = r#"
 /// _:e0 <http://example.org/vocab#next> _:e1 .
 /// _:e0 <http://example.org/vocab#prev> _:e2 .
 /// _:e1 <http://example.org/vocab#next> _:e2 .
@@ -218,7 +218,7 @@ pub fn issue_with_options(
 ///     ("e1".to_string(), "c14n2".to_string()),
 ///     ("e2".to_string(), "c14n1".to_string()),
 /// ]);
-/// let expected_doc = r#"
+/// let expected = r#"
 /// _:c14n0 <http://example.org/vocab#next> _:c14n2 .
 /// _:c14n0 <http://example.org/vocab#prev> _:c14n1 .
 /// _:c14n2 <http://example.org/vocab#next> _:c14n1 .
@@ -227,19 +227,19 @@ pub fn issue_with_options(
 /// _:c14n1 <http://example.org/vocab#prev> _:c14n2 .
 /// "#;
 ///
-/// let quads = NQuadsParser::new()
-///     .parse_from_read(Cursor::new(input_doc))
+/// let input_quads = NQuadsParser::new()
+///     .parse_from_read(Cursor::new(input))
 ///     .into_iter()
 ///     .map(|x| x.unwrap());
-/// let input_dataset = Dataset::from_iter(quads);
+/// let input_dataset = Dataset::from_iter(input_quads);
 /// let labeled_dataset = relabel(&input_dataset, &issued_identifiers_map).unwrap();
-/// let quads = NQuadsParser::new()
-///     .parse_from_read(Cursor::new(expected_doc))
+/// let expected_quads = NQuadsParser::new()
+///     .parse_from_read(Cursor::new(expected))
 ///     .into_iter()
 ///     .map(|x| x.unwrap());
-/// let expected = Dataset::from_iter(quads);
+/// let expected_dataset = Dataset::from_iter(expected_quads);
 ///
-/// assert_eq!(labeled_dataset, expected);
+/// assert_eq!(labeled_dataset, expected_dataset);
 /// ```
 pub fn relabel(
     input_dataset: &Dataset,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,8 @@ pub mod error;
 #[cfg(feature = "log")]
 pub mod logger;
 pub use crate::api::{
-    canonicalize, canonicalize_with_options, issue, issue_with_options, relabel,
+    canonicalize, canonicalize_quads, canonicalize_quads_with_options, canonicalize_with_options,
+    issue, issue_quads, issue_quads_with_options, issue_with_options, relabel, relabel_quads,
     CanonicalizationOptions,
 };
 pub use crate::error::CanonicalizationError;


### PR DESCRIPTION
- add `*_quads` APIs to allow input in `Vec<quad>` instead of `Dataset`
