### PR TITLE
v0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rdf-canon"
 authors = ["yamdan"]
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -9,14 +9,14 @@ edition = "2021"
 [dependencies]
 base16ct = "0.2"
 itertools = "0.11"
-oxrdf = { git = "https://github.com/oxigraph/oxigraph.git", version = "0.2.0-alpha.1-dev", rev = "db7fab0" }
+oxrdf = { git = "https://github.com/oxigraph/oxigraph.git", rev = "922023b" } # will be fixed once next version of oxrdf is published on crates.io
 sha2 = "0.10"
 thiserror = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", optional = true }
 
 [dev-dependencies]
-oxttl = { git = "https://github.com/oxigraph/oxigraph.git", version = "0.1.0-alpha.1-dev", rev = "db7fab0" }
+oxttl = { git = "https://github.com/oxigraph/oxigraph.git", rev = "922023b" } # will be fixed once oxttl is published on crates.io
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/README.md
+++ b/README.md
@@ -7,18 +7,20 @@ Its purpose is for understanding and evaluating the specification, and it's **no
 
 ## Prerequisites
 
-- [Oxrdf and Oxttl (from `next` branch of Oxigraph)](https://github.com/oxigraph/oxigraph/tree/next): These libraries are used to parse N-Quads and handle RDF data structures. Please note that Oxttl is currently only available in the `next` branch of Oxigraph. We'll update this information when Oxigraph officially releases its next version.
+This implementation relies on the upcoming version of [Oxrdf](https://github.com/oxigraph/oxigraph/tree/next) for handling RDF data structures.
+If you aim to canonicalize N-Quads documents rather than Oxrdf Datasets, you'll additionally require [Oxttl](https://github.com/oxigraph/oxigraph/tree/next) for N-Quads parsing.
+Be aware that these crates are currently only accessible in the `next` branch of Oxigraph.
+We plan to update these Git dependencies once Oxigraph officially releases them on [crates.io](https://crates.io).
 
 ## Usage
 
 Add the following dependencies into your Cargo.toml:
-(**Current limitation**: dependency on `next` branch of Oxigraph to use `oxttl`; this will be updated once Oxigraph v0.4 is released)
 
 ```toml
 [dependencies]
 rdf-canon = { git = "https://github.com/yamdan/rdf-canon-rust.git" }
-oxrdf = { git = "https://github.com/oxigraph/oxigraph.git", branch = "next" }
-oxttl = { git = "https://github.com/oxigraph/oxigraph.git", branch = "next" }
+oxrdf = { git = "https://github.com/oxigraph/oxigraph.git", rev = "922023b" } # will be fixed once next version of oxrdf is published on crates.io
+oxttl = { git = "https://github.com/oxigraph/oxigraph.git", rev = "922023b" } # will be fixed once oxttl is published on crates.io
 ```
 
 You can then use the `rdf_canon::canonicalize` to convert OxRDF `Dataset` into canonical N-Quads.
@@ -226,6 +228,12 @@ ca:
 ```
 
 ## Changelog
+
+### v0.11.0
+
+- re-export `serialize` function to enable direct use by users
+- update `oxrdf` and `oxttl` dependencies
+- add more detailed explanation about `oxrdf` and `oxttl` dependencies to the README
 
 ### v0.10.1
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub use crate::api::{
     issue, issue_quads, issue_quads_with_options, issue_with_options, relabel, relabel_quads,
     CanonicalizationOptions,
 };
+pub use crate::canon::serialize;
 pub use crate::error::CanonicalizationError;
 #[cfg(feature = "log")]
 pub use crate::logger::YamlLayer;


### PR DESCRIPTION
- re-export `serialize` function to enable direct use by users
- update `oxrdf` and `oxttl` dependencies
- add more detailed explanation about `oxrdf` and `oxttl` dependencies to the README
