### PR TITLE
v0.13.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rdf-canon"
 authors = ["yamdan"]
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add the following dependencies into your Cargo.toml:
 
 ```toml
 [dependencies]
-rdf-canon = { git = "https://github.com/zkp-ld/rdf-canon.git", version = "0.12.0" }
+rdf-canon = { git = "https://github.com/zkp-ld/rdf-canon.git", version = "0.13.0" }
 oxrdf = { git = "https://github.com/oxigraph/oxigraph.git", rev = "922023b" } # will be fixed once next version of oxrdf is published on crates.io
 oxttl = { git = "https://github.com/oxigraph/oxigraph.git", rev = "922023b" } # will be fixed once oxttl is published on crates.io
 ```
@@ -181,7 +181,7 @@ The YAML-formatted debug log can be obtained by enabling the `log` feature.
 
 ```toml
 [dependencies]
-rdf-canon = { git = "https://github.com/zkp-ld/rdf-canon.git", version = "0.12.0", features = ["log"]  }
+rdf-canon = { git = "https://github.com/zkp-ld/rdf-canon.git", version = "0.13.0", features = ["log"]  }
 oxrdf = { git = "https://github.com/oxigraph/oxigraph.git", rev = "922023b" } # will be fixed once next version of oxrdf is published on crates.io
 oxttl = { git = "https://github.com/oxigraph/oxigraph.git", rev = "922023b" } # will be fixed once oxttl is published on crates.io
 ```
@@ -275,6 +275,10 @@ ca:
 ```
 
 ## Changelog
+
+### v0.13.0
+
+- add `sort` and `sort_graph` functions to sort canonicalized `Dataset` and `Graph` to get `Vec<Quad>` and `Vec<Triple>`, respectively
 
 ### v0.12.0
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,8 @@ pub mod logger;
 pub use crate::api::{
     canonicalize, canonicalize_graph, canonicalize_graph_with, canonicalize_quads,
     canonicalize_quads_with, canonicalize_with, issue, issue_graph, issue_graph_with, issue_quads,
-    issue_quads_with, issue_with, relabel, relabel_graph, relabel_quads, CanonicalizationOptions,
+    issue_quads_with, issue_with, relabel, relabel_graph, relabel_quads, sort, sort_graph,
+    CanonicalizationOptions,
 };
 pub use crate::canon::serialize;
 pub use crate::error::CanonicalizationError;


### PR DESCRIPTION
- add `sort` and `sort_graph` functions to sort canonicalized `Dataset` and `Graph` to get `Vec<Quad>` and `Vec<Triple>`, respectively