### PR TITLE
Upstream maintenance & make six API functions public

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,19 +12,19 @@ license = "MIT"
 
 [dependencies]
 base16ct = { version = "0.2", features = ["alloc"] }
+digest = "0.10"
 itertools = "0.14"
 oxrdf = "0.2.4"
-digest = "0.10"
 sha2 = "0.10"
 thiserror = "2.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", optional = true }
 
 [dev-dependencies]
+chrono = "0.4"
 oxttl = "0.1.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-chrono = "0.4"
 
 [features]
 log = ["tracing-subscriber"]

--- a/src/api.rs
+++ b/src/api.rs
@@ -21,7 +21,7 @@ use std::collections::HashMap;
 /// use oxttl::NQuadsParser;
 /// use rdf_canon::canonicalize;
 /// use std::io::Cursor;
-
+///
 /// let input = r#"_:e0 <http://example.org/vocab#next> _:e1 _:g .
 /// _:e0 <http://example.org/vocab#prev> _:e2 _:g .
 /// _:e1 <http://example.org/vocab#next> _:e2 _:g .
@@ -62,7 +62,7 @@ pub fn canonicalize(input_dataset: &Dataset) -> Result<String, CanonicalizationE
 /// use oxttl::NTriplesParser;
 /// use rdf_canon::canonicalize_graph;
 /// use std::io::Cursor;
-
+///
 /// let input = r#"_:e0 <http://example.org/vocab#next> _:e1 .
 /// _:e0 <http://example.org/vocab#prev> _:e2 .
 /// _:e1 <http://example.org/vocab#next> _:e2 .
@@ -103,7 +103,7 @@ pub fn canonicalize_graph(input_graph: &Graph) -> Result<String, Canonicalizatio
 /// use oxttl::NQuadsParser;
 /// use rdf_canon::canonicalize_quads;
 /// use std::io::Cursor;
-
+///
 /// let input = r#"_:e0 <http://example.org/vocab#next> _:e1 _:g .
 /// _:e0 <http://example.org/vocab#prev> _:e2 _:g .
 /// _:e1 <http://example.org/vocab#next> _:e2 _:g .
@@ -151,7 +151,7 @@ pub struct CanonicalizationOptions {
 /// use rdf_canon::{canonicalize_with, CanonicalizationOptions};
 /// use sha2::Sha256;
 /// use std::io::Cursor;
-
+///
 /// let input = r#"_:e0 <http://example.org/vocab#next> _:e1 _:g .
 /// _:e0 <http://example.org/vocab#prev> _:e2 _:g .
 /// _:e1 <http://example.org/vocab#next> _:e2 _:g .
@@ -201,7 +201,7 @@ pub fn canonicalize_with<D: Digest>(
 /// use rdf_canon::{canonicalize_graph_with, CanonicalizationOptions};
 /// use sha2::Sha256;
 /// use std::io::Cursor;
-
+///
 /// let input = r#"_:e0 <http://example.org/vocab#next> _:e1 .
 /// _:e0 <http://example.org/vocab#prev> _:e2 .
 /// _:e1 <http://example.org/vocab#next> _:e2 .
@@ -251,7 +251,7 @@ pub fn canonicalize_graph_with<D: Digest>(
 /// use rdf_canon::{canonicalize_quads_with, CanonicalizationOptions};
 /// use sha2::Sha256;
 /// use std::io::Cursor;
-
+///
 /// let input = r#"_:e0 <http://example.org/vocab#next> _:e1 _:g .
 /// _:e0 <http://example.org/vocab#prev> _:e2 _:g .
 /// _:e1 <http://example.org/vocab#next> _:e2 _:g .

--- a/src/api.rs
+++ b/src/api.rs
@@ -730,7 +730,7 @@ pub fn relabel_quads(
         .collect()
 }
 
-fn relabel_quad(
+pub fn relabel_quad(
     q: QuadRef,
     issued_identifiers_map: &HashMap<String, String>,
 ) -> Result<Quad, CanonicalizationError> {
@@ -742,7 +742,7 @@ fn relabel_quad(
     ))
 }
 
-fn relabel_triple(
+pub fn relabel_triple(
     t: TripleRef,
     issued_identifiers_map: &HashMap<String, String>,
 ) -> Result<Triple, CanonicalizationError> {
@@ -753,7 +753,7 @@ fn relabel_triple(
     ))
 }
 
-fn relabel_subject(
+pub fn relabel_subject(
     s: SubjectRef,
     issued_identifiers_map: &HashMap<String, String>,
 ) -> Result<Subject, CanonicalizationError> {
@@ -768,7 +768,7 @@ fn relabel_subject(
     }
 }
 
-fn relabel_term(
+pub fn relabel_term(
     o: TermRef,
     issued_identifiers_map: &HashMap<String, String>,
 ) -> Result<Term, CanonicalizationError> {
@@ -783,7 +783,7 @@ fn relabel_term(
     }
 }
 
-fn relabel_graph_name(
+pub fn relabel_graph_name(
     g: GraphNameRef,
     issued_identifiers_map: &HashMap<String, String>,
 ) -> Result<GraphName, CanonicalizationError> {
@@ -798,7 +798,7 @@ fn relabel_graph_name(
     }
 }
 
-fn relabel_blank_node(
+pub fn relabel_blank_node(
     b: BlankNodeRef,
     issued_identifiers_map: &HashMap<String, String>,
 ) -> Result<BlankNode, CanonicalizationError> {

--- a/src/canon.rs
+++ b/src/canon.rs
@@ -51,7 +51,7 @@ impl CanonicalizationState {
             if let SubjectRef::BlankNode(n) = &quad.subject {
                 self.blank_node_to_quads_map
                     .entry(n.as_str().to_string())
-                    .or_insert_with(Vec::<Quad>::new)
+                    .or_default()
                     .push(quad.into());
             }
             // 2.1) For each blank node that is a component of Q, add a reference to Q from the map
@@ -60,7 +60,7 @@ impl CanonicalizationState {
             if let TermRef::BlankNode(n) = &quad.object {
                 self.blank_node_to_quads_map
                     .entry(n.as_str().to_string())
-                    .or_insert_with(Vec::<Quad>::new)
+                    .or_default()
                     .push(quad.into());
             }
             // 2.1) For each blank node that is a component of Q, add a reference to Q from the map
@@ -69,7 +69,7 @@ impl CanonicalizationState {
             if let GraphNameRef::BlankNode(n) = &quad.graph_name {
                 self.blank_node_to_quads_map
                     .entry(n.as_str().to_string())
-                    .or_insert_with(Vec::<Quad>::new)
+                    .or_default()
                     .push(quad.into());
             }
         }
@@ -260,7 +260,7 @@ pub fn canonicalize_core<D: Digest>(
         state
             .hash_to_blank_node_map
             .entry(hash)
-            .or_insert_with(Vec::<String>::new)
+            .or_default()
             .push(n.clone());
     }
 
@@ -627,9 +627,9 @@ fn hash_related_blank_node<D: Digest>(
     let span_hrbn_3 = debug_span!("").entered();
 
     let identifier = match state.canonical_issuer.get(related) {
-        Some(id) => format!("_:{}", id),
+        Some(id) => format!("_:{id}"),
         None => match issuer.get(related) {
-            Some(id) => format!("_:{}", id),
+            Some(id) => format!("_:{id}"),
             // 4) Otherwise, append the result of the Hash First Degree Quads algorithm,
             // passing related to input.
             None => hash_first_degree_quads::<D>(state, related)?,
@@ -639,7 +639,7 @@ fn hash_related_blank_node<D: Digest>(
     #[cfg(feature = "log")]
     span_hrbn_3.exit();
 
-    let input = format!("{}{}", input, identifier);
+    let input = format!("{input}{identifier}");
 
     #[cfg(feature = "log")]
     debug!(indent = 1, "input: \"{}\"", input);
@@ -786,7 +786,7 @@ fn hash_n_degree_quads<D: Digest>(
                 // 3.1.2) Add a mapping of hash to the blank node identifier for component to Hn,
                 // adding an entry as necessary.
                 h_n.entry(hash)
-                    .or_insert_with(Vec::<String>::new)
+                    .or_default()
                     .push(bnode_id);
             };
         };
@@ -817,7 +817,7 @@ fn hash_n_degree_quads<D: Digest>(
                 // 3.1.2) Add a mapping of hash to the blank node identifier for component to Hn,
                 // adding an entry as necessary.
                 h_n.entry(hash)
-                    .or_insert_with(Vec::<String>::new)
+                    .or_default()
                     .push(bnode_id);
             };
         };
@@ -847,7 +847,7 @@ fn hash_n_degree_quads<D: Digest>(
                 // 3.1.2) Add a mapping of hash to the blank node identifier for component to Hn,
                 // adding an entry as necessary.
                 h_n.entry(hash)
-                    .or_insert_with(Vec::<String>::new)
+                    .or_default()
                     .push(bnode_id);
             };
         };
@@ -952,7 +952,7 @@ fn hash_n_degree_quads<D: Digest>(
                     // 5.4.4.1) If a canonical identifier has been issued for related by
                     // canonical issuer, append the string _:, followed by the canonical
                     // identifier for related, to path.
-                    path_vec.push(format!("_:{}", canonical_identifier));
+                    path_vec.push(format!("_:{canonical_identifier}"));
                 } else {
                     // 5.4.4.2) Otherwise:
                     // 5.4.4.2.1) If issuer copy has not issued an identifier for
@@ -1380,7 +1380,7 @@ mod tests {
             state
                 .hash_to_blank_node_map
                 .entry(hash)
-                .or_insert_with(Vec::<String>::new)
+                .or_default()
                 .push(n.clone());
         }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,7 +11,9 @@ pub enum CanonicalizationError {
     CanonicalIdentifierNotExist,
     #[error("Parsing blank node identifier failed.")]
     BlankNodeIdParseError,
-    #[error("The number of calls to the Hash N-degree Quads algorithm have exceeded the limit of {0}.")]
+    #[error(
+        "The number of calls to the Hash N-degree Quads algorithm have exceeded the limit of {0}."
+    )]
     HndqCallLimitExceeded(usize),
 }
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -23,7 +23,7 @@ where
         ctx: tracing_subscriber::layer::Context<'_, S>,
     ) {
         // get span name
-        let Some(span ) = ctx.span(id) else { return };
+        let Some(span) = ctx.span(id) else { return };
         let span_name = span.metadata().name();
 
         // get parent indent


### PR DESCRIPTION
The maintenance commits should be self-explaining.

the reason for making the 6 functions public:

These are useful for users of the library,
if they have both a graph and separate `Vec`s or `HashMap`s
referencing parts of the graph
(e.g. all subjects of special interest).
To canonicalize in this scenario,
one would want to create the mapping with `issue` on the graph,
and then apply this mapping both to that graph
and to the separate collections of items in the graph.

---

Thanks for this library! :-)
I know you suggest not to use it in production code, but.. I do ;-)
no worries though, it is no critical application, and users have to specifically opt in to use the canonicalization feature.